### PR TITLE
Add Invisible Emotion Detector API

### DIFF
--- a/InvisibleEmotionDetector.sln
+++ b/InvisibleEmotionDetector.sln
@@ -1,0 +1,38 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InvisibleEmotionDetector.Api", "src/Api/InvisibleEmotionDetector.Api.csproj", "{BFCABD35-5CEF-431E-9FBC-EB7E0CC61BD9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InvisibleEmotionDetector.Application", "src/Application/InvisibleEmotionDetector.Application.csproj", "{06DD9A75-E94C-4D49-9E7D-3DCDE14A0E38}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InvisibleEmotionDetector.Domain", "src/Domain/InvisibleEmotionDetector.Domain.csproj", "{DB68D8C1-6F7D-4D6A-8FA0-D2B2756E8DF3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InvisibleEmotionDetector.Infrastructure", "src/Infrastructure/InvisibleEmotionDetector.Infrastructure.csproj", "{F56DF0AA-E24E-43E0-B5E8-5364D1EA0D64}"
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {BFCABD35-5CEF-431E-9FBC-EB7E0CC61BD9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {BFCABD35-5CEF-431E-9FBC-EB7E0CC61BD9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {BFCABD35-5CEF-431E-9FBC-EB7E0CC61BD9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {BFCABD35-5CEF-431E-9FBC-EB7E0CC61BD9}.Release|Any CPU.Build.0 = Release|Any CPU
+        {06DD9A75-E94C-4D49-9E7D-3DCDE14A0E38}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {06DD9A75-E94C-4D49-9E7D-3DCDE14A0E38}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {06DD9A75-E94C-4D49-9E7D-3DCDE14A0E38}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {06DD9A75-E94C-4D49-9E7D-3DCDE14A0E38}.Release|Any CPU.Build.0 = Release|Any CPU
+        {DB68D8C1-6F7D-4D6A-8FA0-D2B2756E8DF3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {DB68D8C1-6F7D-4D6A-8FA0-D2B2756E8DF3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {DB68D8C1-6F7D-4D6A-8FA0-D2B2756E8DF3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {DB68D8C1-6F7D-4D6A-8FA0-D2B2756E8DF3}.Release|Any CPU.Build.0 = Release|Any CPU
+        {F56DF0AA-E24E-43E0-B5E8-5364D1EA0D64}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {F56DF0AA-E24E-43E0-B5E8-5364D1EA0D64}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {F56DF0AA-E24E-43E0-B5E8-5364D1EA0D64}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {F56DF0AA-E24E-43E0-B5E8-5364D1EA0D64}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
+EndGlobal
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,85 @@
-"# invisible-emotion-api" 
+# Invisible Emotion Detector
+
+Invisible Emotion Detector is a Web API inspired by neutrino physics. It allows users to capture daily emotional inputs and reveals subtle patterns over time. The project follows Clean Architecture principles and uses ASP.NET Core 8 with Entity Framework Core and JWT authentication.
+
+## Getting Started
+
+### Prerequisites
+* .NET 8 SDK
+
+### Running Locally
+```bash
+# Restore dependencies
+dotnet restore
+
+# Run database migrations (if any)
+dotnet ef database update --project src/Infrastructure --startup-project src/Api
+
+# Start the API
+dotnet run --project src/Api
+```
+The API will be available at `https://localhost:5001` by default.
+
+## API Usage
+
+### Register
+`POST /api/auth/register`
+```json
+{
+  "userName": "alice",
+  "email": "alice@example.com",
+  "password": "Pass123$"
+}
+```
+
+### Login
+`POST /api/auth/login`
+```json
+{
+  "userName": "alice",
+  "password": "Pass123$"
+}
+```
+Response contains a JWT token:
+```json
+{
+  "token": "{jwt}" 
+}
+```
+Include this token in the `Authorization` header as `Bearer {jwt}` to access protected endpoints.
+
+### Submit Emotion Input
+`POST /api/emotion-inputs`
+```json
+{
+  "emotion": "happy",
+  "description": "Sunshine outside"
+}
+```
+
+### Get Patterns
+`GET /api/emotion-patterns`
+
+### Get Insights
+`GET /api/insights`
+
+## Project Structure
+```
+src/
+  Api/            # Presentation layer (controllers, Program.cs, Swagger)
+  Application/    # DTOs, services and interfaces
+  Domain/         # Core domain entities and interfaces
+  Infrastructure/ # Persistence and repository implementations
+```
+
+## Authentication Details
+The API uses JWT bearer tokens. On successful login, include the token in the `Authorization` header of subsequent requests. Swagger UI is configured to accept the token for testing.
+
+## Technologies Used
+* .NET 8 Web API
+* Entity Framework Core with SQLite
+* Swagger (Swashbuckle)
+* JWT Authentication
+
+## License
+This project is licensed under the MIT License.

--- a/src/Api/Controllers/AuthController.cs
+++ b/src/Api/Controllers/AuthController.cs
@@ -1,0 +1,31 @@
+using InvisibleEmotionDetector.Application.DTOs;
+using InvisibleEmotionDetector.Application.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+
+namespace InvisibleEmotionDetector.Api.Controllers;
+
+[ApiController]
+[Route("auth")]
+public class AuthController : ControllerBase
+{
+    private readonly IAuthService _authService;
+
+    public AuthController(IAuthService authService)
+    {
+        _authService = authService;
+    }
+
+    [HttpPost("register")]
+    public async Task<IActionResult> Register(RegisterRequest request)
+    {
+        await _authService.RegisterAsync(request);
+        return Ok();
+    }
+
+    [HttpPost("login")]
+    public async Task<ActionResult<LoginResponse>> Login(LoginRequest request)
+    {
+        var result = await _authService.LoginAsync(request);
+        return Ok(result);
+    }
+}

--- a/src/Api/Controllers/EmotionInputsController.cs
+++ b/src/Api/Controllers/EmotionInputsController.cs
@@ -1,0 +1,28 @@
+using System.Security.Claims;
+using InvisibleEmotionDetector.Application.DTOs;
+using InvisibleEmotionDetector.Application.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace InvisibleEmotionDetector.Api.Controllers;
+
+[ApiController]
+[Authorize]
+[Route("emotion-inputs")]
+public class EmotionInputsController : ControllerBase
+{
+    private readonly IEmotionService _service;
+
+    public EmotionInputsController(IEmotionService service)
+    {
+        _service = service;
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Post(EmotionInputRequest request)
+    {
+        var userId = Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
+        await _service.AddEmotionInputAsync(userId, request);
+        return Ok();
+    }
+}

--- a/src/Api/Controllers/EmotionPatternsController.cs
+++ b/src/Api/Controllers/EmotionPatternsController.cs
@@ -1,0 +1,28 @@
+using System.Security.Claims;
+using InvisibleEmotionDetector.Application.Interfaces;
+using InvisibleEmotionDetector.Application.DTOs;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace InvisibleEmotionDetector.Api.Controllers;
+
+[ApiController]
+[Authorize]
+[Route("emotion-patterns")]
+public class EmotionPatternsController : ControllerBase
+{
+    private readonly IEmotionService _service;
+
+    public EmotionPatternsController(IEmotionService service)
+    {
+        _service = service;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<List<EmotionPatternDto>>> Get()
+    {
+        var userId = Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
+        var result = await _service.GetPatternsAsync(userId);
+        return Ok(result);
+    }
+}

--- a/src/Api/Controllers/InsightsController.cs
+++ b/src/Api/Controllers/InsightsController.cs
@@ -1,0 +1,28 @@
+using System.Security.Claims;
+using InvisibleEmotionDetector.Application.Interfaces;
+using InvisibleEmotionDetector.Application.DTOs;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace InvisibleEmotionDetector.Api.Controllers;
+
+[ApiController]
+[Authorize]
+[Route("insights")]
+public class InsightsController : ControllerBase
+{
+    private readonly IEmotionService _service;
+
+    public InsightsController(IEmotionService service)
+    {
+        _service = service;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<List<InsightDto>>> Get()
+    {
+        var userId = Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
+        var result = await _service.GetInsightsAsync(userId);
+        return Ok(result);
+    }
+}

--- a/src/Api/Conventions/RoutePrefixConvention.cs
+++ b/src/Api/Conventions/RoutePrefixConvention.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
+
+namespace InvisibleEmotionDetector.Api.Conventions;
+
+public class RoutePrefixConvention : IApplicationModelConvention
+{
+    private readonly AttributeRouteModel _routePrefix;
+
+    public RoutePrefixConvention(string prefix)
+    {
+        _routePrefix = new AttributeRouteModel(new Microsoft.AspNetCore.Mvc.RouteAttribute(prefix));
+    }
+
+    public void Apply(ApplicationModel application)
+    {
+        foreach (var controller in application.Controllers)
+        {
+            foreach (var selector in controller.Selectors)
+            {
+                if (selector.AttributeRouteModel != null)
+                {
+                    selector.AttributeRouteModel = AttributeRouteModel.CombineAttributeRouteModel(_routePrefix, selector.AttributeRouteModel);
+                }
+                else
+                {
+                    selector.AttributeRouteModel = _routePrefix;
+                }
+            }
+        }
+    }
+}

--- a/src/Api/InvisibleEmotionDetector.Api.csproj
+++ b/src/Api/InvisibleEmotionDetector.Api.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Application/InvisibleEmotionDetector.Application.csproj" />
+    <ProjectReference Include="../Infrastructure/InvisibleEmotionDetector.Infrastructure.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+  </ItemGroup>
+</Project>

--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -1,0 +1,84 @@
+using System.Text;
+using InvisibleEmotionDetector.Api.Conventions;
+using InvisibleEmotionDetector.Infrastructure.Extensions;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddInfrastructure(builder.Configuration);
+builder.Services.AddControllers();
+builder.Services.AddCors(options =>
+{
+    options.AddDefaultPolicy(policy =>
+    {
+        policy.AllowAnyOrigin().AllowAnyHeader().AllowAnyMethod();
+    });
+});
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(c =>
+{
+    c.SwaggerDoc("v1", new() { Title = "Invisible Emotion Detector", Version = "v1" });
+    c.AddSecurityDefinition("Bearer", new Microsoft.OpenApi.Models.OpenApiSecurityScheme
+    {
+        In = Microsoft.OpenApi.Models.ParameterLocation.Header,
+        Description = "Please enter JWT with Bearer into field",
+        Name = "Authorization",
+        Type = Microsoft.OpenApi.Models.SecuritySchemeType.ApiKey
+    });
+    c.AddSecurityRequirement(new Microsoft.OpenApi.Models.OpenApiSecurityRequirement
+    {
+        {
+            new Microsoft.OpenApi.Models.OpenApiSecurityScheme
+            {
+                Reference = new Microsoft.OpenApi.Models.OpenApiReference { Type = Microsoft.OpenApi.Models.ReferenceType.SecurityScheme, Id = "Bearer" }
+            },
+            new string[]{}
+        }
+    });
+});
+
+builder.Services.AddMvc(options =>
+{
+    options.Conventions.Insert(0, new RoutePrefixConvention("api"));
+});
+
+var jwtKey = builder.Configuration["Jwt:Key"] ?? "SuperSecretKeyChangeMe";
+var key = Encoding.ASCII.GetBytes(jwtKey);
+builder.Services.AddAuthentication(options =>
+{
+    options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+    options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+})
+.AddJwtBearer(options =>
+{
+    options.RequireHttpsMetadata = false;
+    options.SaveToken = true;
+    options.TokenValidationParameters = new TokenValidationParameters
+    {
+        ValidateIssuerSigningKey = true,
+        IssuerSigningKey = new SymmetricSecurityKey(key),
+        ValidateIssuer = false,
+        ValidateAudience = false
+    };
+});
+
+var app = builder.Build();
+
+app.UseCors();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();
+
+public partial class Program { }

--- a/src/Api/appsettings.json
+++ b/src/Api/appsettings.json
@@ -1,0 +1,15 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Data Source=emotion.db"
+  },
+  "Jwt": {
+    "Key": "SuperSecretKeyChangeMe"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/Application/DTOs/EmotionInputRequest.cs
+++ b/src/Application/DTOs/EmotionInputRequest.cs
@@ -1,0 +1,3 @@
+namespace InvisibleEmotionDetector.Application.DTOs;
+
+public record EmotionInputRequest(string Emotion, string? Description);

--- a/src/Application/DTOs/EmotionPatternDto.cs
+++ b/src/Application/DTOs/EmotionPatternDto.cs
@@ -1,0 +1,3 @@
+namespace InvisibleEmotionDetector.Application.DTOs;
+
+public record EmotionPatternDto(string Description);

--- a/src/Application/DTOs/InsightDto.cs
+++ b/src/Application/DTOs/InsightDto.cs
@@ -1,0 +1,3 @@
+namespace InvisibleEmotionDetector.Application.DTOs;
+
+public record InsightDto(string Message, DateTime CreatedAt);

--- a/src/Application/DTOs/LoginRequest.cs
+++ b/src/Application/DTOs/LoginRequest.cs
@@ -1,0 +1,3 @@
+namespace InvisibleEmotionDetector.Application.DTOs;
+
+public record LoginRequest(string UserName, string Password);

--- a/src/Application/DTOs/LoginResponse.cs
+++ b/src/Application/DTOs/LoginResponse.cs
@@ -1,0 +1,3 @@
+namespace InvisibleEmotionDetector.Application.DTOs;
+
+public record LoginResponse(string Token);

--- a/src/Application/DTOs/RegisterRequest.cs
+++ b/src/Application/DTOs/RegisterRequest.cs
@@ -1,0 +1,3 @@
+namespace InvisibleEmotionDetector.Application.DTOs;
+
+public record RegisterRequest(string UserName, string Email, string Password);

--- a/src/Application/Interfaces/IAuthService.cs
+++ b/src/Application/Interfaces/IAuthService.cs
@@ -1,0 +1,9 @@
+using InvisibleEmotionDetector.Application.DTOs;
+
+namespace InvisibleEmotionDetector.Application.Interfaces;
+
+public interface IAuthService
+{
+    Task RegisterAsync(RegisterRequest request, CancellationToken cancellationToken = default);
+    Task<LoginResponse> LoginAsync(LoginRequest request, CancellationToken cancellationToken = default);
+}

--- a/src/Application/Interfaces/IEmotionService.cs
+++ b/src/Application/Interfaces/IEmotionService.cs
@@ -1,0 +1,10 @@
+using InvisibleEmotionDetector.Application.DTOs;
+
+namespace InvisibleEmotionDetector.Application.Interfaces;
+
+public interface IEmotionService
+{
+    Task AddEmotionInputAsync(Guid userId, EmotionInputRequest request, CancellationToken cancellationToken = default);
+    Task<List<EmotionPatternDto>> GetPatternsAsync(Guid userId, CancellationToken cancellationToken = default);
+    Task<List<InsightDto>> GetInsightsAsync(Guid userId, CancellationToken cancellationToken = default);
+}

--- a/src/Application/InvisibleEmotionDetector.Application.csproj
+++ b/src/Application/InvisibleEmotionDetector.Application.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Domain/InvisibleEmotionDetector.Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Application/Services/AuthService.cs
+++ b/src/Application/Services/AuthService.cs
@@ -1,0 +1,60 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using BCrypt.Net;
+using InvisibleEmotionDetector.Application.DTOs;
+using InvisibleEmotionDetector.Application.Interfaces;
+using InvisibleEmotionDetector.Domain.Entities;
+using InvisibleEmotionDetector.Domain.Interfaces;
+using Microsoft.Extensions.Configuration;
+using Microsoft.IdentityModel.Tokens;
+
+namespace InvisibleEmotionDetector.Application.Services;
+
+public class AuthService : IAuthService
+{
+    private readonly IGenericRepository<User> _users;
+    private readonly IConfiguration _configuration;
+
+    public AuthService(IGenericRepository<User> users, IConfiguration configuration)
+    {
+        _users = users;
+        _configuration = configuration;
+    }
+
+    public async Task RegisterAsync(RegisterRequest request, CancellationToken cancellationToken = default)
+    {
+        var user = new User
+        {
+            Id = Guid.NewGuid(),
+            UserName = request.UserName,
+            Email = request.Email,
+            PasswordHash = BCrypt.Net.BCrypt.HashPassword(request.Password)
+        };
+        await _users.AddAsync(user, cancellationToken);
+    }
+
+    public async Task<LoginResponse> LoginAsync(LoginRequest request, CancellationToken cancellationToken = default)
+    {
+        var user = await _users.FindAsync(u => u.UserName == request.UserName, cancellationToken);
+        if (user == null || !BCrypt.Net.BCrypt.Verify(request.Password, user.PasswordHash))
+        {
+            throw new UnauthorizedAccessException("Invalid credentials");
+        }
+
+        var tokenHandler = new JwtSecurityTokenHandler();
+        var key = Encoding.ASCII.GetBytes(_configuration["Jwt:Key"]!);
+        var tokenDescriptor = new SecurityTokenDescriptor
+        {
+            Subject = new ClaimsIdentity(new[]
+            {
+                new Claim(ClaimTypes.NameIdentifier, user.Id.ToString()),
+                new Claim(ClaimTypes.Name, user.UserName)
+            }),
+            Expires = DateTime.UtcNow.AddHours(1),
+            SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(key), SecurityAlgorithms.HmacSha256Signature)
+        };
+        var token = tokenHandler.CreateToken(tokenDescriptor);
+        return new LoginResponse(tokenHandler.WriteToken(token));
+    }
+}

--- a/src/Application/Services/EmotionService.cs
+++ b/src/Application/Services/EmotionService.cs
@@ -1,0 +1,41 @@
+using InvisibleEmotionDetector.Application.DTOs;
+using InvisibleEmotionDetector.Application.Interfaces;
+using InvisibleEmotionDetector.Domain.Entities;
+using InvisibleEmotionDetector.Domain.Interfaces;
+
+namespace InvisibleEmotionDetector.Application.Services;
+
+public class EmotionService : IEmotionService
+{
+    private readonly IEmotionRepository _repository;
+
+    public EmotionService(IEmotionRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task AddEmotionInputAsync(Guid userId, EmotionInputRequest request, CancellationToken cancellationToken = default)
+    {
+        var input = new EmotionInput
+        {
+            Id = Guid.NewGuid(),
+            Emotion = request.Emotion,
+            Description = request.Description,
+            Timestamp = DateTime.UtcNow,
+            UserId = userId
+        };
+        await _repository.AddEmotionInputAsync(input, cancellationToken);
+    }
+
+    public async Task<List<EmotionPatternDto>> GetPatternsAsync(Guid userId, CancellationToken cancellationToken = default)
+    {
+        var patterns = await _repository.GetPatternsAsync(userId, cancellationToken);
+        return patterns.Select(p => new EmotionPatternDto(p.Description)).ToList();
+    }
+
+    public async Task<List<InsightDto>> GetInsightsAsync(Guid userId, CancellationToken cancellationToken = default)
+    {
+        var insights = await _repository.GetInsightsAsync(userId, cancellationToken);
+        return insights.Select(i => new InsightDto(i.Message, i.CreatedAt)).ToList();
+    }
+}

--- a/src/Domain/Entities/EmotionInput.cs
+++ b/src/Domain/Entities/EmotionInput.cs
@@ -1,0 +1,12 @@
+namespace InvisibleEmotionDetector.Domain.Entities;
+
+public class EmotionInput
+{
+    public Guid Id { get; set; }
+    public string Emotion { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public DateTime Timestamp { get; set; }
+    public Guid UserId { get; set; }
+
+    public User? User { get; set; }
+}

--- a/src/Domain/Entities/EmotionPattern.cs
+++ b/src/Domain/Entities/EmotionPattern.cs
@@ -1,0 +1,9 @@
+namespace InvisibleEmotionDetector.Domain.Entities;
+
+public class EmotionPattern
+{
+    public Guid Id { get; set; }
+    public string Description { get; set; } = string.Empty;
+    public Guid UserId { get; set; }
+    public User? User { get; set; }
+}

--- a/src/Domain/Entities/Insight.cs
+++ b/src/Domain/Entities/Insight.cs
@@ -1,0 +1,10 @@
+namespace InvisibleEmotionDetector.Domain.Entities;
+
+public class Insight
+{
+    public Guid Id { get; set; }
+    public string Message { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; }
+    public Guid UserId { get; set; }
+    public User? User { get; set; }
+}

--- a/src/Domain/Entities/User.cs
+++ b/src/Domain/Entities/User.cs
@@ -1,0 +1,11 @@
+namespace InvisibleEmotionDetector.Domain.Entities;
+
+public class User
+{
+    public Guid Id { get; set; }
+    public string UserName { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public string PasswordHash { get; set; } = string.Empty;
+
+    public ICollection<EmotionInput> EmotionInputs { get; set; } = new List<EmotionInput>();
+}

--- a/src/Domain/Interfaces/IEmotionRepository.cs
+++ b/src/Domain/Interfaces/IEmotionRepository.cs
@@ -1,0 +1,10 @@
+using InvisibleEmotionDetector.Domain.Entities;
+
+namespace InvisibleEmotionDetector.Domain.Interfaces;
+
+public interface IEmotionRepository
+{
+    Task AddEmotionInputAsync(EmotionInput input, CancellationToken cancellationToken = default);
+    Task<List<EmotionPattern>> GetPatternsAsync(Guid userId, CancellationToken cancellationToken = default);
+    Task<List<Insight>> GetInsightsAsync(Guid userId, CancellationToken cancellationToken = default);
+}

--- a/src/Domain/Interfaces/IGenericRepository.cs
+++ b/src/Domain/Interfaces/IGenericRepository.cs
@@ -1,0 +1,10 @@
+using System.Linq.Expressions;
+
+namespace InvisibleEmotionDetector.Domain.Interfaces;
+
+public interface IGenericRepository<T> where T : class
+{
+    Task AddAsync(T entity, CancellationToken cancellationToken = default);
+    Task<T?> FindAsync(Expression<Func<T, bool>> predicate, CancellationToken cancellationToken = default);
+    Task<List<T>> WhereAsync(Expression<Func<T, bool>> predicate, CancellationToken cancellationToken = default);
+}

--- a/src/Domain/InvisibleEmotionDetector.Domain.csproj
+++ b/src/Domain/InvisibleEmotionDetector.Domain.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/src/Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,24 @@
+using InvisibleEmotionDetector.Application.Interfaces;
+using InvisibleEmotionDetector.Application.Services;
+using InvisibleEmotionDetector.Domain.Entities;
+using InvisibleEmotionDetector.Domain.Interfaces;
+using InvisibleEmotionDetector.Infrastructure.Persistence;
+using InvisibleEmotionDetector.Infrastructure.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace InvisibleEmotionDetector.Infrastructure.Extensions;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddInfrastructure(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddDbContext<AppDbContext>(options => options.UseSqlite(configuration.GetConnectionString("DefaultConnection")));
+        services.AddScoped<IGenericRepository<User>, GenericRepository<User>>();
+        services.AddScoped<IEmotionRepository, EmotionRepository>();
+        services.AddScoped<IAuthService, AuthService>();
+        services.AddScoped<IEmotionService, EmotionService>();
+        return services;
+    }
+}

--- a/src/Infrastructure/InvisibleEmotionDetector.Infrastructure.csproj
+++ b/src/Infrastructure/InvisibleEmotionDetector.Infrastructure.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Domain/InvisibleEmotionDetector.Domain.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.0" />
+  </ItemGroup>
+</Project>

--- a/src/Infrastructure/Persistence/AppDbContext.cs
+++ b/src/Infrastructure/Persistence/AppDbContext.cs
@@ -1,0 +1,21 @@
+using InvisibleEmotionDetector.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace InvisibleEmotionDetector.Infrastructure.Persistence;
+
+public class AppDbContext : DbContext
+{
+    public AppDbContext(DbContextOptions<AppDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<User> Users => Set<User>();
+    public DbSet<EmotionInput> EmotionInputs => Set<EmotionInput>();
+    public DbSet<EmotionPattern> EmotionPatterns => Set<EmotionPattern>();
+    public DbSet<Insight> Insights => Set<Insight>();
+
+    protected override void OnModelCreating(ModelBuilder builder)
+    {
+        base.OnModelCreating(builder);
+    }
+}

--- a/src/Infrastructure/Repositories/EmotionRepository.cs
+++ b/src/Infrastructure/Repositories/EmotionRepository.cs
@@ -1,0 +1,32 @@
+using InvisibleEmotionDetector.Domain.Entities;
+using InvisibleEmotionDetector.Domain.Interfaces;
+using InvisibleEmotionDetector.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace InvisibleEmotionDetector.Infrastructure.Repositories;
+
+public class EmotionRepository : IEmotionRepository
+{
+    private readonly AppDbContext _context;
+
+    public EmotionRepository(AppDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task AddEmotionInputAsync(EmotionInput input, CancellationToken cancellationToken = default)
+    {
+        await _context.EmotionInputs.AddAsync(input, cancellationToken);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task<List<EmotionPattern>> GetPatternsAsync(Guid userId, CancellationToken cancellationToken = default)
+    {
+        return await _context.EmotionPatterns.Where(p => p.UserId == userId).ToListAsync(cancellationToken);
+    }
+
+    public async Task<List<Insight>> GetInsightsAsync(Guid userId, CancellationToken cancellationToken = default)
+    {
+        return await _context.Insights.Where(i => i.UserId == userId).ToListAsync(cancellationToken);
+    }
+}

--- a/src/Infrastructure/Repositories/GenericRepository.cs
+++ b/src/Infrastructure/Repositories/GenericRepository.cs
@@ -1,0 +1,33 @@
+using System.Linq.Expressions;
+using InvisibleEmotionDetector.Domain.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace InvisibleEmotionDetector.Infrastructure.Repositories;
+
+public class GenericRepository<T> : IGenericRepository<T> where T : class
+{
+    private readonly DbContext _context;
+    private readonly DbSet<T> _dbSet;
+
+    public GenericRepository(DbContext context)
+    {
+        _context = context;
+        _dbSet = context.Set<T>();
+    }
+
+    public async Task AddAsync(T entity, CancellationToken cancellationToken = default)
+    {
+        await _dbSet.AddAsync(entity, cancellationToken);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task<T?> FindAsync(Expression<Func<T, bool>> predicate, CancellationToken cancellationToken = default)
+    {
+        return await _dbSet.FirstOrDefaultAsync(predicate, cancellationToken);
+    }
+
+    public async Task<List<T>> WhereAsync(Expression<Func<T, bool>> predicate, CancellationToken cancellationToken = default)
+    {
+        return await _dbSet.Where(predicate).ToListAsync(cancellationToken);
+    }
+}


### PR DESCRIPTION
## Summary
- implement Clean Architecture solution for Invisible Emotion Detector
- add domain entities and repositories
- create application DTOs and services
- add infrastructure persistence layer with EF Core and DI
- implement Web API controllers with JWT authentication and CORS
- set up Swagger and route prefix convention
- document project in README

## Testing
- `dotnet build InvisibleEmotionDetector.sln` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ae71ba0f883278d178dac4e75113d